### PR TITLE
Fix installation section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ TypeLang Parser is available as Composer repository and can be installed
 using the following command in a root of your project:
 
 ```sh
-$ composer require type-lang/parser
+composer require type-lang/parser
 ```
 
 ## Quick Start


### PR DESCRIPTION
The installation instruction doesn't work in a good way when I copy-paste it into the terminal.

![image](https://github.com/php-type-language/parser/assets/4152481/bb1bd553-feb5-4326-a5e1-bf1469ca5270)
